### PR TITLE
Fix FP register rename regression

### DIFF
--- a/gcc/ChangeLog.epiphany
+++ b/gcc/ChangeLog.epiphany
@@ -1,3 +1,9 @@
+2014-10-29  Ola Jeppsson  <ola@adapteva.com>
+
+	* config/epiphany/epiphany.md (stack_adjust_add_fp, stack_adjust_mov):
+	Use fp instead of r15. Fixes one aspect of the regression introduced by
+	commit "(GPR_FP): Change to 11" (c4d6b17f514ef85f85811eecb514191216c19610)
+
 2014-09-25  Simon Cook  <simon.cook@embecosm.com>
 
 	* config/epiphany/epiphany.h (EPIPHANY_LIBRARY_EXTRA_SPEC): Don't

--- a/gcc/config/epiphany/epiphany.md
+++ b/gcc/config/epiphany/epiphany.md
@@ -2549,13 +2549,13 @@
    (clobber (reg:SI STATUS_REGNUM))
    (clobber (match_operand:BLK 1 "memory_operand" "=m"))]
   "reload_completed"
-  "add sp,r15,%0")
+  "add sp,fp,%0")
 
 (define_insn "stack_adjust_mov"
   [(set (reg:SI GPR_SP) (reg:SI GPR_FP))
    (clobber (match_operand:BLK 0 "memory_operand" "=m"))]
   "reload_completed"
-  "mov sp,r15"
+  "mov sp,fp"
   [(set_attr "type" "move")])
 
 (define_insn "stack_adjust_str"


### PR DESCRIPTION
- config/epiphany/epiphany.md (stack_adjust_add_fp, stack_adjust_mov):  
  Use FP instead of hardcoded R15. Fixes regression introduced by  
  commit "(GPR_FP): Change to 11" (c4d6b17f514ef85f85811eecb514191216c19610)
