### PR TITLE
Update epiphany.h - Fix dobule alignment bug

### DIFF
--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -1008,13 +1008,18 @@ crisv32-*-linux* | cris-*-linux*)
 		;;
 	esac
 	;;
-epiphany-*-elf )
+epiphany-*-elf | epiphany-*-rtems* )
 	tm_file="dbxelf.h elfos.h newlib-stdint.h ${tm_file}"
 	tmake_file="epiphany/t-epiphany"
 	extra_options="${extra_options} fused-madd.opt"
 	extra_objs="$extra_objs mode-switch-use.o resolve-sw-modes.o"
 	tm_defines="${tm_defines} EPIPHANY_STACK_OFFSET=${with_stack_offset:-8}"
 	extra_headers="epiphany_intrinsics.h"
+  case ${target} in
+  epiphany-*-rtems* )
+    tm_file="${tm_file} epiphany/rtems.h rtems.h"
+    ;;
+  esac
 	;;
 fr30-*-elf)
 	tm_file="dbxelf.h elfos.h newlib-stdint.h ${tm_file}"

--- a/gcc/config/epiphany/epiphany.h
+++ b/gcc/config/epiphany/epiphany.h
@@ -120,7 +120,7 @@ along with GCC; see the file COPYING3.  If not see
     }
 
 /* Allocation boundary (in *bits*) for storing arguments in argument list.  */
-#define PARM_BOUNDARY 64
+#define PARM_BOUNDARY 32
 
 /* Boundary (in *bits*) on which stack pointer should be aligned.  */
 #define STACK_BOUNDARY 64

--- a/gcc/config/epiphany/epiphany.h
+++ b/gcc/config/epiphany/epiphany.h
@@ -120,7 +120,7 @@ along with GCC; see the file COPYING3.  If not see
     }
 
 /* Allocation boundary (in *bits*) for storing arguments in argument list.  */
-#define PARM_BOUNDARY 32
+#define PARM_BOUNDARY 64
 
 /* Boundary (in *bits*) on which stack pointer should be aligned.  */
 #define STACK_BOUNDARY 64

--- a/gcc/config/epiphany/rtems.h
+++ b/gcc/config/epiphany/rtems.h
@@ -1,0 +1,33 @@
+/* Definitions for rtems targeting a RTEMS using ELF.
+   Copyright (C) 2014 Free Software Foundation, Inc.
+   Contributed by Joel Sherrill (joel@OARcorp.com).
+
+This file is part of GCC.
+
+GCC is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3, or (at your option)
+any later version.
+
+GCC is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GCC; see the file COPYING3.  If not see
+<http://www.gnu.org/licenses/>.  */
+
+/* Target OS builtins.  */
+#undef TARGET_OS_CPP_BUILTINS
+#define TARGET_OS_CPP_BUILTINS()		\
+  do						\
+    {						\
+	builtin_define ("__rtems__");		\
+	builtin_define ("__USE_INIT_FINI__");	\
+	builtin_assert ("system=rtems");	\
+    }						\
+  while (0)
+
+/* Use the default */
+#undef LINK_GCC_C_SEQUENCE_SPEC

--- a/libgcc/config.host
+++ b/libgcc/config.host
@@ -405,7 +405,7 @@ cris-*-elf)
 cris-*-linux* | crisv32-*-linux*)
 	tmake_file="$tmake_file cris/t-cris t-fdpbit cris/t-linux"
 	;;
-epiphany-*-elf*)
+epiphany-*-elf* | epiphany-*-rtems*)
 	tmake_file="epiphany/t-epiphany t-fdpbit epiphany/t-custom-eqsf"
 	extra_parts="$extra_parts crti.o crtint.o crtrunc.o crtm1reg-r43.o crtm1reg-r63.o crtn.o"
 	;;


### PR DESCRIPTION
Copying/Passing structures (by value) as function parameters emits strd/ldrd instructions that need the data (in that case the structures passed as function parameters, and specifically with strd) to be aligned to 8 bytes, otherwise it will cause unalignment exception.
